### PR TITLE
add Packit support

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,22 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: pagure-exporter.spec
+
+# add or remove files that should be synced
+files_to_sync:
+    - pagure-exporter.spec
+    - .packit.yaml
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  targets:
+    - fedora-rawhide
+    - fedora-40
+
+
+# name in upstream package repository or registry (e.g. in PyPI)
+upstream_package_name: pagure-exporter
+# downstream (Fedora) RPM package name
+downstream_package_name: pagure-exporter


### PR DESCRIPTION
Hi @gridhead! I followed the guide on [Packit docs](https://packit.dev/docs/guide#1-set-up-packit-integration) and installed Packit on my local machine (Fedora 39 on Windows 11 via WSL), and on running `packit init` it generated the `.packit.yaml` file.

Feel free to let me know if you need anything else. 

(Will close #109)