### PR TITLE
chore: updated copyright years across all the codebase headers

### DIFF
--- a/pagure_exporter/__init__.py
+++ b/pagure_exporter/__init__.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/conf/__init__.py
+++ b/pagure_exporter/conf/__init__.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/conf/standard.py
+++ b/pagure_exporter/conf/standard.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/main.py
+++ b/pagure_exporter/main.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/view/__init__.py
+++ b/pagure_exporter/view/__init__.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/view/dcrt.py
+++ b/pagure_exporter/view/dcrt.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/view/misc.py
+++ b/pagure_exporter/view/misc.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/view/repo.py
+++ b/pagure_exporter/view/repo.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/view/stat.py
+++ b/pagure_exporter/view/stat.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/view/tkts.py
+++ b/pagure_exporter/view/tkts.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/work/__init__.py
+++ b/pagure_exporter/work/__init__.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/work/keep.py
+++ b/pagure_exporter/work/keep.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/work/repo.py
+++ b/pagure_exporter/work/repo.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/work/stat.py
+++ b/pagure_exporter/work/stat.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/pagure_exporter/work/tkts.py
+++ b/pagure_exporter/work/tkts.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/test/test_stat.py
+++ b/test/test_stat.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/test/test_tkts.py
+++ b/test/test_tkts.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/test/test_unit_gitlab.py
+++ b/test/test_unit_gitlab.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/test/test_unit_repo.py
+++ b/test/test_unit_repo.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/test/test_unit_tkts.py
+++ b/test/test_unit_tkts.py
@@ -1,6 +1,6 @@
 """
 Pagure Exporter
-Copyright (C) 2022-2023 Akashdeep Dhar
+Copyright (C) 2022-2025 Akashdeep Dhar
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
Updated copyright years from `2022-2023` to `2022-2025`