### PR TITLE
Replace `@` with `&` in the ticket title

### DIFF
--- a/pagure_exporter/work/tkts.py
+++ b/pagure_exporter/work/tkts.py
@@ -163,12 +163,13 @@ class MoveTickets:
                 mm=datetime.fromtimestamp(standard.comment_creation_time, timezone.utc).strftime("%M"),
             )
             """
-            Replace "@" in the `body_data` with "&" to ensure that wrong people are not referenced
-            in the destination namespace
-            Check https://github.com/gridhead/pagure-exporter/issues/7 for more information about
+            Replace "@" in the `header_data` and `body_data` with "&" to ensure that wrong people
+            are not referenced in the destination namespace
+            Check https://github.com/gridhead/pagure-exporter/issues/7 and
+            https://github.com/fedora-infra/pagure-exporter/issues/204 for more information about
             the problem
             """
-            request_data = {"title": header_data, "description": body_data.replace("@", "&")}
+            request_data = {"title": header_data.replace("@", "&"), "description": body_data.replace("@", "&")}
             if standard.move_labels:
                 request_data["labels"] = standard.ticket_labels
             if standard.move_secret:


### PR DESCRIPTION
Hey!

This changes in this PR replaces `@` with `&` in the ticket title while creating them in the destination so as to not reference the wrong people and not send notifications of the transfer.

It implements the similar logic used for replacing `@` with `&` in the ticket description or the comment bodies.

Thanks you for reviewing the PR and let me know if you feel something else need to changed which I might have missed.

Fixes: #204 