### PR TITLE
Trigger `CI` to run on `push` or `pull_request` towards `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 ---
 name: pagure-exporter
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   ci-basic:
     strategy:


### PR DESCRIPTION
Hey!

The change in the PR makes sure GitHub `CI` runs on `push` or `pull_request` towards `main` branch.

`CI` runs on below cases:
1. Open PR into main
2. Force push to PR branch
3. Merge PR to main